### PR TITLE
Fix for testing using Event::fake()

### DIFF
--- a/src/FCMChannel.php
+++ b/src/FCMChannel.php
@@ -3,7 +3,7 @@
 namespace NotificationChannels\FCM;
 
 use LaravelFCM\Sender\FCMSender;
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\FCM\Exceptions\CouldNotSendNotification;
 

--- a/tests/FCMChannelTest.php
+++ b/tests/FCMChannelTest.php
@@ -4,7 +4,7 @@ namespace NotificationChannels\FCM\Test;
 
 use Mockery;
 use LaravelFCM\Sender\FCMSender;
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Notifiable;
 use NotificationChannels\FCM\FCMChannel;
 use NotificationChannels\FCM\FCMMessage;


### PR DESCRIPTION
Use the Dispatcher contract instead of the class so we can use any Dispatcher, such as the fake provided by Laravel when using Event::fake().

Fixes this error during testing with Event::fake():
````
Symfony\Component\Debug\Exception\FatalThrowableError: Argument 2 passed to NotificationChannels\FCM\FCMChannel::__construct() must be an instance of Illuminate\Events\Dispatcher, instance of Illuminate\Support\Testing\Fakes\EventFake given
````
